### PR TITLE
Add href options to share-card and details

### DIFF
--- a/packages/kwc-share-card/demo/index.js
+++ b/packages/kwc-share-card/demo/index.js
@@ -133,7 +133,7 @@ const card = html`
     }
 </style>
 
-<kwc-share-card id="share-card" title="Kevin86's Goes to the MOON" username="Kevin86" date="2019-05-23T10:48:21.053Z">
+<kwc-share-card id="share-card" title="Kevin86's Goes to the MOON" username="Kevin86" date="2019-05-23T10:48:21.053Z" title-href="https://world.kano.me" username-href="https://world.kano.me">
     <iron-image slot="cover" style="width: 100%; height: 192px;" src="https://hoc-staging.kano.me/assets/images/build_challenges/orbit_moon.svg"
         sizing="cover" preload fade>
     </iron-image>

--- a/packages/kwc-share-card/kwc-share-card.js
+++ b/packages/kwc-share-card/kwc-share-card.js
@@ -119,9 +119,6 @@ class KwcShareCard extends PolymerElement {
                 text-decoration: none;
                 color: black;
             }
-            .avatar-anchor {
-                position: relative;
-            }
         </style>
 
         <div class="wrapper">

--- a/packages/kwc-share-card/kwc-share-card.js
+++ b/packages/kwc-share-card/kwc-share-card.js
@@ -115,24 +115,33 @@ class KwcShareCard extends PolymerElement {
             #moderation {
                 height: 100px;
             }
+            a {
+                text-decoration: none;
+                color: black;
+            }
+            .avatar-anchor {
+                position: relative;
+            }
         </style>
 
         <div class="wrapper">
             <div class="cover">
                 <slot name="cover"></slot>
                 <paper-spinner class="spinner" active hidden$="[[!uploadingAvatar]]"></paper-spinner>
-                <iron-image class="avatar" on-click="_onTapAvatar" src$="[[_avatar]]" sizing="contain" hidden$="[[uploadingAvatar]]" disabled$="[[avatarDisabled]]"></iron-image>
+                <a class="avatar" on-click="_onTapAvatar" href$="[[avatarHref]]">
+                    <iron-image src$="[[_avatar]]" sizing="contain" hidden$="[[uploadingAvatar]]" disabled$="[[avatarDisabled]]"></iron-image>
+                </a>
             </div>
             <template is="dom-if" if="[[!moderationPending]]">
-                <div class="title" on-click="_onTapTitle">
+                <a class="title" on-click="_onTapTitle" href$="[[titleHref]]">
                     <div class="title-text">[[title]]</div>
                     <!-- If you want to mark this post with an icon (for example animation)
                     you can slot it into this \`title-icon\` slot -->
                     <div class="title-icon"><slot name="title-icon"></slot></div>
-                </div>
-                <div class="username" on-click="_onTapUsername">
+                </a>
+                <a class="username" on-click="_onTapUsername" href$="[[usernameHref]]">
                     [[_(byLabel, 'by')]] <span class="username-text"> [[username]]</span>[[_(prefixAgo, '')]] [[_timeSince(date, timeAgoLocales)]] [[_(suffixAgo, 'ago')]]
-                </div>
+                </a>
                 <div id="actions">
                     <slot name="actions"></slot>
                 </div>
@@ -141,7 +150,6 @@ class KwcShareCard extends PolymerElement {
                         <slot name="details"></slot>
                     </div>
                 </template>
-                
             </template>
             <template is="dom-if" if="[[moderationPending]]">
                 <div id="moderation">
@@ -191,6 +199,13 @@ class KwcShareCard extends PolymerElement {
                 notify: true,
                 reflectToAttribute: true,
             },
+            moderationPending: {
+                type: Boolean,
+                value: false,
+            },
+            titleHref: String,
+            usernameHref: String,
+            avatarHref: String,
             byLabel: String,
             prefixAgo: String,
             suffixAgo: String,

--- a/packages/kwc-share-detail/kwc-share-detail.js
+++ b/packages/kwc-share-detail/kwc-share-detail.js
@@ -503,9 +503,9 @@ class KwcShareDetail extends PolymerElement {
             <div class="share-detail">
                 <div class="main-details">
                     <div class="header">
-                        <div class="avatar-wrapper">
-                            <iron-image class="avatar" src="[[_avatarUrl]]" sizing="cover" on-click="_onUserTapped" preload fade></iron-image>
-                        </div>
+                        <a class="avatar-wrapper" on-click="_onUserTapped" href$="[[avatarHref]]">
+                            <iron-image class="avatar" src="[[_avatarUrl]]" sizing="cover" preload fade></iron-image>
+                        </a>
                         <div class="detail">
                             <h3 class="title">
                                 <slot name="title-icon"></slot>
@@ -514,7 +514,7 @@ class KwcShareDetail extends PolymerElement {
                                 </iron-image>
                             </h3>
                             <h4 class="attribution">[[_(byLabel, 'by')]]
-                                <a class="author" on-click="_onUserTapped">[[shareData.username]]</a>
+                                <a class="author" on-click="_onUserTapped" href$="[[usernameHref]]">[[shareData.username]]</a>
                             </h4>
                             <p class="description">[[shareData.description]]</p>
                             <div class="actions">
@@ -526,7 +526,7 @@ class KwcShareDetail extends PolymerElement {
                                 </button>
                             </template>
                             <template is="dom-if" if="[[_showRemixButton(shareData, canRemix)]]">
-                                <button class="btn action remix" on-click="_onRemixTapped">${remix}<div>[[_(remixLabel, 'Remix')]]</div></button>
+                                <a class="btn action remix" on-click="_onRemixTapped" href$="[[remixHref]]">${remix}<div>[[_(remixLabel, 'Remix')]]</div></a>
                             </template>
                             <template is="dom-if" if="[[_showCodeButton(shareData)]]">
                                 <button class="btn action view-code" on-click="_toggleCodeView">${code}<div>[[_(viewCodeLabel, 'View&nbsp;code')]]</div></button>
@@ -559,8 +559,24 @@ class KwcShareDetail extends PolymerElement {
                                 is available -->
                     <iron-pages id="social-sections" selected="[[_section]]" attr-for-selected="section-name" fallback-selection="comments">
                         <div section-name="comments" class="social-section">
-                            <kwc-social-comments id="comments" comments="[[comments.entries]]" default-avatar="[[_defaultCommentAvatarUrl]]" next-page="[[comments.page]]" item-id="[[shareData.id]]" tombstone$="[[!shareData]]" user="[[currentUser]]" loader-status="[[commentLoaderStatus]]" comment-flags="[[commentFlags]]" on-delete-comment="_handleDeleteComment" on-load-comment="_handleLoadComment" on-post-comment="_handlePostComment" on-flag-comment="_handleFlagComment" on-unflag-comment="_handleUnflagComment" on-view-user="_handleViewUser">
-                                                    </kwc-social-comments>
+                            <kwc-social-comments id="comments"
+                                                comments="[[comments.entries]]"
+                                                default-avatar="[[_defaultCommentAvatarUrl]]"
+                                                next-page="[[comments.page]]"
+                                                item-id="[[shareData.id]]"
+                                                tombstone$="[[!shareData]]"
+                                                user="[[currentUser]]"
+                                                loader-status="[[commentLoaderStatus]]"
+                                                comment-flags="[[commentFlags]]"
+                                                username-href="[[usernameHref]]"
+                                                avatar-href="[[avatarHref]]"
+                                                on-delete-comment="_handleDeleteComment"
+                                                on-load-comment="_handleLoadComment"
+                                                on-post-comment="_handlePostComment"
+                                                on-flag-comment="_handleFlagComment"
+                                                on-unflag-comment="_handleUnflagComment"
+                                                on-view-user="_handleViewUser">
+                                        </kwc-social-comments>
                         </div>
                     </iron-pages>
                 </div>
@@ -879,6 +895,9 @@ class KwcShareDetail extends PolymerElement {
                 type: Boolean,
                 value: false,
             },
+            usernameHref: String,
+            avatarHref: String,
+            remixHref: String,
             byLabel: String,
             remixLabel: String,
             viewCodeLabel: String,


### PR DESCRIPTION
 - Add href options for username, avatar and title. This will allow us to give URLs instead of using event, enabling actions like ctrl+click/mouse middle button to open in new tab. This will also allow us to open the make art app from the Kano Code app when users try to remix a make art share
 - Add `moderationPending` property definition with default value